### PR TITLE
Fix 'function' is not a member of 'std'.

### DIFF
--- a/lib/direct/Base.h
+++ b/lib/direct/Base.h
@@ -56,6 +56,7 @@ extern "C" {
 #include <memory>
 #include <set>
 #include <string>
+#include <functional>
 
 #include <stdexcept>
 


### PR DESCRIPTION
This pull request fixes the following error (Issue #8):
```
In file included from Base.cpp:42:0:
../../lib/direct/Base.h: In member function ‘_Target& Direct::Base::TypeBase::Convert()’:
../../lib/direct/Base.h:283:63: error: ‘function’ is not a member of ‘std’
                     _Target *t = _Target::template Call< std::function<_Target *(TypeBase *)> >( *source_info.name )( this );
                                                               ^~~~~~~~
../../lib/direct/Base.h:283:63: note: suggested alternative: ‘is_function’
                     _Target *t = _Target::template Call< std::function<_Target *(TypeBase *)> >( *source_info.name )( this );
                                                               ^~~~~~~~
                                                               is_function
../../lib/direct/Base.h:283:63: error: ‘function’ is not a member of ‘std’
../../lib/direct/Base.h:283:63: note: suggested alternative: ‘is_function’
                     _Target *t = _Target::template Call< std::function<_Target *(TypeBase *)> >( *source_info.name )( this );
                                                               ^~~~~~~~
                                                               is_function
../../lib/direct/Base.h:283:52: error: parse error in template argument list
                     _Target *t = _Target::template Call< std::function<_Target *(TypeBase *)> >( *source_info.name )( this );
                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../lib/direct/Base.h:283:124: error: expression cannot be used as a function
                     _Target *t = _Target::template Call< std::function<_Target *(TypeBase *)> >( *source_info.name )( this );
                                                                                                                            ^
  
```